### PR TITLE
Add firmware build guides and PID test

### DIFF
--- a/01-onoff_control/README.md
+++ b/01-onoff_control/README.md
@@ -1,0 +1,20 @@
+# On/Off Control Firmware
+
+This folder contains the simplest firmware example using a bang-bang
+controller for the LED brightness demo.
+
+## Building with CMake
+1. Install the ARM `gcc-arm-none-eabi` toolchain and ensure
+   `arm-none-eabi-gcc` is in your `PATH`.
+2. Configure and build using the presets:
+   ```bash
+   cmake --preset Debug
+   cmake --build build/Debug
+   ```
+   The resulting ELF binary can be flashed to the board from the
+   `build/Debug` directory.
+
+## Building with STM32CubeIDE
+1. Open `01-onoff_control.ioc` in STM32CubeIDE.
+2. Let the IDE generate the project files if prompted.
+3. Click **Build** to compile and **Run** to flash the board.

--- a/02-proportional-control/README.md
+++ b/02-proportional-control/README.md
@@ -1,0 +1,19 @@
+# Proportional Control Firmware
+
+This stage introduces a simple proportional controller implemented on an
+STM32F446 microcontroller.
+
+## Building with CMake
+1. Install the ARM `gcc-arm-none-eabi` toolchain.
+2. Configure and build using the provided presets:
+   ```bash
+   cmake --preset Debug
+   cmake --build build/Debug
+   ```
+   The final binary `02-proportional-control.elf` will appear in
+   `build/Debug`.
+
+## Building with STM32CubeIDE
+1. Open `02-proportional-control.ioc` in STM32CubeIDE.
+2. Generate the project when prompted.
+3. Use the IDE's **Build** button to compile and flash the firmware.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+project(pid_tests C)
+
+set(CMAKE_C_STANDARD 11)
+
+add_executable(pid_test pid_test.c ../02-proportional-control/Core/Src/pid.c)
+target_include_directories(pid_test PRIVATE ../02-proportional-control/Core/Inc)
+target_link_libraries(pid_test m)
+
+enable_testing()
+add_test(NAME pid_test COMMAND pid_test)

--- a/tests/pid_test.c
+++ b/tests/pid_test.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <math.h>
+#include "../02-proportional-control/Core/Inc/pid.h"
+
+int main(void) {
+    pid_t pid;
+    pid_init(&pid, 1.0f, 100.0f, 0.0f, 100.0f);
+
+    float out = pid_compute(&pid, 100.0f);
+    assert(fabsf(out - 0.0f) < 1e-6);
+
+    out = pid_compute(&pid, 0.0f);
+    assert(fabsf(out - 100.0f) < 1e-6);
+
+    out = pid_compute(&pid, 200.0f);
+    assert(fabsf(out - 0.0f) < 1e-6);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- document how to build each firmware with CMake or STM32CubeIDE
- add host-based unit test for PID calculations

## Testing
- `cmake -S tests -B build && cmake --build build && ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_6874563405488323afcfd47b7c3a6339