### PR TITLE
Update UART plotter usage

### DIFF
--- a/uart_plotter/USAGE.md
+++ b/uart_plotter/USAGE.md
@@ -8,7 +8,7 @@ cd uart_plotter
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python uart_plot.py
+python uart_plot.py --serial-port /dev/ttyUSB0
 ```
 
 ---
@@ -21,7 +21,24 @@ cd uart_plotter
 python -m venv venv
 venv\Scripts\activate   # or .\venv\Scripts\Activate.ps1 in PowerShell
 pip install -r requirements.txt
-python uart_plot.py
+python uart_plot.py --serial-port COM5
 ```
 
 ---
+
+## Key Controls
+
+- Press `r` to toggle raw ADC data.
+- Press `s` to toggle scaled values.
+- Press `p` to toggle PWM duty cycle.
+
+Example session:
+
+```text
+$ python uart_plot.py --serial-port /dev/ttyUSB0
+Logging from /dev/ttyUSB0 at 115200
+Saving to log_20250713_123456.csv
+Raw display ON
+Scaled display ON
+PWM display ON
+```

--- a/uart_plotter/uart_plot.py
+++ b/uart_plotter/uart_plot.py
@@ -1,3 +1,4 @@
+import argparse
 import serial
 import re
 import csv
@@ -7,9 +8,19 @@ import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
 # === CONFIG ===
-SERIAL_PORT = '/dev/tty.usbmodem1103' 
+DEFAULT_SERIAL_PORT = '/dev/tty.usbmodem1103'
 BAUD_RATE = 115200
 MAX_POINTS = 200
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Real-time UART plotting tool")
+parser.add_argument(
+    "--serial-port",
+    default=DEFAULT_SERIAL_PORT,
+    help="Serial device to read from (e.g. /dev/ttyUSB0 or COM5)",
+)
+args = parser.parse_args()
+SERIAL_PORT = args.serial_port
 
 # === CSV LOG SETUP ===
 csv_filename = f"log_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"


### PR DESCRIPTION
## Summary
- add `--serial-port` argument to `uart_plot.py`
- document how to use the new argument
- list key controls and show example output

## Testing
- `python -m py_compile uart_plotter/uart_plot.py`
- `python uart_plotter/uart_plot.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6874562c8ccc832393fbc092ed7a69b2