### PR TITLE
Add CLI port option for uart_plotter

### DIFF
--- a/uart_plotter/USAGE.md
+++ b/uart_plotter/USAGE.md
@@ -8,7 +8,8 @@ cd uart_plotter
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python uart_plot.py
+# replace /dev/ttyACM0 with your serial port
+python uart_plot.py --port /dev/ttyACM0
 ```
 
 ---
@@ -21,7 +22,8 @@ cd uart_plotter
 python -m venv venv
 venv\Scripts\activate   # or .\venv\Scripts\Activate.ps1 in PowerShell
 pip install -r requirements.txt
-python uart_plot.py
+# replace COM3 with the serial port shown in Device Manager
+python uart_plot.py --port COM3
 ```
 
 ---

--- a/uart_plotter/uart_plot.py
+++ b/uart_plotter/uart_plot.py
@@ -5,11 +5,20 @@ import time
 from datetime import datetime
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
+import argparse
 
 # === CONFIG ===
-SERIAL_PORT = '/dev/tty.usbmodem1103' 
+DEFAULT_PORT = '/dev/tty.usbmodem1103'
 BAUD_RATE = 115200
 MAX_POINTS = 200
+
+# === ARGUMENTS ===
+parser = argparse.ArgumentParser(description='Plot and log UART output')
+parser.add_argument('-p', '--port', default=DEFAULT_PORT,
+                    help='Serial port to read from (default: %(default)s)')
+args = parser.parse_args()
+
+SERIAL_PORT = args.port
 
 # === CSV LOG SETUP ===
 csv_filename = f"log_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"


### PR DESCRIPTION
## Summary
- allow overriding the serial port in `uart_plot.py`
- update usage instructions with `--port` option

## Testing
- `python3 -m py_compile uart_plotter/uart_plot.py`

------
https://chatgpt.com/codex/tasks/task_e_6874561cd5608323ae3a9ba5b2c66edb