### PR TITLE
Fix photocell header include case

### DIFF
--- a/01-onoff_control/Core/Src/photocell.c
+++ b/01-onoff_control/Core/Src/photocell.c
@@ -1,4 +1,4 @@
-#include "PhotoCell.h"
+#include "photocell.h"
 #include "stm32f4xx_hal.h"  // or whatever matches your MCU
 
 extern ADC_HandleTypeDef hadc1;  // Your global ADC handle

--- a/02-proportional-control/Core/Src/main.c
+++ b/02-proportional-control/Core/Src/main.c
@@ -21,7 +21,7 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-#include "PhotoCell.h"
+#include "photocell.h"
 #include "led_pwm.h"
 #include "logger.h"
 #include "photocell.h"

--- a/02-proportional-control/Core/Src/photocell.c
+++ b/02-proportional-control/Core/Src/photocell.c
@@ -1,4 +1,4 @@
-#include "PhotoCell.h"
+#include "photocell.h"
 #include "stm32f4xx_hal.h"  // or whatever matches your MCU
 
 extern ADC_HandleTypeDef hadc1;  // Your global ADC handle


### PR DESCRIPTION
## Summary
- update photocell.c to include `photocell.h`
- update proportional control sources accordingly
- verify firmware builds for both demos

## Testing
- `cmake --build --preset Debug` in `01-onoff_control`
- `cmake --build --preset Debug` in `02-proportional-control`


------
https://chatgpt.com/codex/tasks/task_e_687455f2ed4083238c77650683b7782a