### PR TITLE
Improve README clarity and typo fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cmake_install.cmake
 .ninja_deps
 .ninja_log
 .DS_Store
+build/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Each folder documents a distinct control strategy:
 1. `01-onoff_control` — Basic bang-bang control
 2. `02-proportional_control` — Smooth response with proportional feedback
 
-Additional stages for PI and full PID control will be added as development continues.
+Planned lessons:
+3. `03-pi_control` — Adds integral action to remove steady-state error
+4. `04-pid_control` — Full PID with derivative damping
 
 Each stage includes:
 - Firmware source code
@@ -36,8 +38,8 @@ Each stage includes:
 ![Kp set to 1.2 in graph](image.png)
 Note: The image shows the LED brightness response with Kp set to 1.2, demonstrating the system's behavior under proportional control.
 
-![Setup of STM32F446 Nucleo and breadboard with optoresistor and led wired to board.  External 3.3V supply is connected to the breadboard.](image-1.png)
+![Setup of STM32F446 Nucleo and breadboard with photoresistor and led wired to board.  External 3.3V supply is connected to the breadboard.](image-1.png)
 Note: This image shows the hardware setup with the STM32F446 Nucleo board, LED, and CDS-55 photoresistor connected to a breadboard with an external 3.3V supply.
 
-![This image shows the photresistor spacing relative to the LED.  In the testing it was covered to prvent noise from ambient light.](image-2.png)
+![This image shows the photoresistor spacing relative to the LED.  In the testing it was covered to prevent noise from ambient light.](image-2.png)
 Note: The photoresistor is positioned relative to the LED, covered to minimize noise from ambient light during testing.


### PR DESCRIPTION
## Summary
- expand README with planned lessons
- fix typos in README
- ignore build directory

## Testing
- `cmake ../tests`
- `cmake --build .`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_687465d388fc83239c4220337d93045f