### PR TITLE
Add UART telemetry and command features

### DIFF
--- a/02-proportional-control/Core/Inc/logger.h
+++ b/02-proportional-control/Core/Inc/logger.h
@@ -102,3 +102,39 @@ __attribute__((weak)) void Log_Write_UART(const char* msg);
  * @param msg Null-terminated string to write to file.
  */
 __attribute__((weak)) void Log_Write_SD(const char* msg);
+
+/**
+ * @brief Send simple telemetry data over the logging backend.
+ *
+ * This helper prints a comma separated line of the form
+ * `telemetry,<lux>,<duty>\n` which can be parsed by host tools.
+ *
+ * @param lux_percent  Current light level in percent (0-100)
+ * @param duty_percent Current PWM duty cycle in percent (0-100)
+ */
+void Log_Telemetry(uint8_t lux_percent, uint8_t duty_percent);
+
+/** Callback type used when a command is received over UART. */
+typedef void (*Log_CommandCallback)(const char* cmd);
+
+/**
+ * @brief Register a callback for processing incoming UART commands.
+ *
+ * When characters terminated by a newline are received via UART,
+ * the callback will be invoked with the assembled command string.
+ */
+void Log_SetCommandCallback(Log_CommandCallback cb);
+
+/**
+ * @brief Poll the UART for incoming bytes and dispatch completed commands.
+ *
+ * Call periodically from the main loop to process command input.
+ */
+void Log_Poll(void);
+
+/**
+ * @brief Default handler for received commands (weak).
+ *        Applications may override this to implement custom behaviour.
+ * @param cmd Null-terminated command string.
+ */
+__attribute__((weak)) void Log_CommandReceived(const char* cmd);

--- a/02-proportional-control/Core/Src/logger.c
+++ b/02-proportional-control/Core/Src/logger.c
@@ -223,7 +223,11 @@ void Log_Poll(void)
 {
 #if LOG_USE_UART
     uint8_t byte;
+    uint16_t iteration_count = 0; // Counter to track iterations
     while (HAL_UART_Receive(&LOG_UART_HANDLE, &byte, 1, 0) == HAL_OK) {
+        if (++iteration_count > LOG_UART_MAX_ITERATIONS) {
+            break; // Exit the loop if the maximum iteration count is reached
+        }
         if (byte == '\n' || byte == '\r') {
             if (cmd_index > 0) {
                 cmd_buffer[cmd_index] = '\0';

--- a/02-proportional-control/Core/Src/logger.c
+++ b/02-proportional-control/Core/Src/logger.c
@@ -234,7 +234,7 @@ void Log_Poll(void)
                 }
                 cmd_index = 0;
             }
-        } else if (cmd_index < sizeof(cmd_buffer) - 1) {
+        } else if (cmd_index < sizeof(cmd_buffer) - 2) {
             cmd_buffer[cmd_index++] = (char)byte;
         }
     }


### PR DESCRIPTION
## Summary
- add telemetry and command callback APIs in `logger.h`
- implement command buffer, polling and telemetry formatter in `logger.c`

## Testing
- `cmake . -B build` and `cmake --build build` in `tests`
- `./build/pid_test`


------
https://chatgpt.com/codex/tasks/task_e_6879849862e48323a1300c3a8929c28f