### PR TITLE
Add CLI controls for PID

### DIFF
--- a/02-proportional-control-v01/Core/Inc/sample_commands.h
+++ b/02-proportional-control-v01/Core/Inc/sample_commands.h
@@ -17,6 +17,12 @@ void cmd_help(Args *args);
 void cmd_echo(Args *args);
 /** Add two integers and output result. */
 void cmd_add(Args *args);
+/** Enable PID control loop. */
+void cmd_pid_start(Args *args);
+/** Disable PID control loop. */
+void cmd_pid_stop(Args *args);
+/** Set proportional gain Kp. */
+void cmd_kp(Args *args);
 
 /** Table of available commands. */
 extern const Command cmd_list[];

--- a/02-proportional-control-v01/Core/Src/main.c
+++ b/02-proportional-control-v01/Core/Src/main.c
@@ -43,6 +43,10 @@ static uart_drv_t uart2_drv;
 uart_drv_t *shared_uart = NULL;
 static SemaphoreHandle_t rx_done_sem;
 PwmChannel_t pwm;
+// PID control parameters and state
+volatile bool pid_enabled = false;
+float pid_kp = 1.0f;
+static const float pid_setpoint = 60.0f;
 
 /* USER CODE END PD */
 
@@ -430,12 +434,22 @@ static void PhotoCellTask(void *arg) {
     for (;;) {
         uint8_t level = readSensor(&sensor, &hadc1);
 
+        if (pid_enabled) {
+            float error = pid_setpoint - level;
+            float duty  = pid_kp * error;
+            if (duty < 0.0f) duty = 0.0f;
+            if (duty > 100.0f) duty = 100.0f;
+            Pwm_setDuty(&pwm, (uint8_t)duty);
+        } else {
+            Pwm_setDuty(&pwm, 0);
+        }
+
         pkt.sensor1++;
         pkt.sensor2 = level;
 
         telemetry_send(&pkt);
 
-        vTaskDelay(pdMS_TO_TICKS(1000));
+        vTaskDelay(pdMS_TO_TICKS(100));
     }
 }
 


### PR DESCRIPTION
## Summary
- add PID control globals and integrate simple proportional loop in `PhotoCellTask`
- expand sample CLI with commands to start/stop the loop and modify Kp

## Testing
- `cmake -S . -B build` and `cmake --build build` in `tests`
- `./build/pid_test`

------
https://chatgpt.com/codex/tasks/task_e_687d44c07a0c8323a4c5a33fa4620726