### PR TITLE
Expose PWM top value via macros

### DIFF
--- a/01-onoff_control/Core/Inc/led_pwm.h
+++ b/01-onoff_control/Core/Inc/led_pwm.h
@@ -5,13 +5,23 @@
 #include <stdint.h>
 #include "logger.h"
 
+/** Maximum input value accepted by ::LedPwm_setDuty. */
+#ifndef LED_PWM_MAX_DUTY
+#define LED_PWM_MAX_DUTY 100U
+#endif
+
+/** Timer top (ARR) value used for 100% duty cycle. */
+#ifndef LED_PWM_TIMER_TOP
+#define LED_PWM_TIMER_TOP 100U
+#endif
+
 /**
  * @brief PWM-controlled LED interface.
  */
 typedef struct {
     TIM_HandleTypeDef* htim;  /**< Pointer to the timer handle */
     uint32_t channel;         /**< Timer channel used for PWM (e.g., TIM_CHANNEL_1) */
-    uint8_t duty_percent;     /**< Current duty cycle percentage (0–100) */
+    uint8_t duty_percent;     /**< Current duty cycle value (0–LED_PWM_MAX_DUTY) */
 } LedPwm_t;
 
 /**

--- a/01-onoff_control/Core/Src/led_pwm.c
+++ b/01-onoff_control/Core/Src/led_pwm.c
@@ -25,15 +25,13 @@ void LedPwm_stop(LedPwm_t* led) {
         led->channel, (void*)led->htim);
 }
 
-void LedPwm_setDuty(LedPwm_t* led, uint8_t duty_percent) {
-    if (duty_percent > 100) duty_percent = 100;
-    led->duty_percent = duty_percent;
+void LedPwm_setDuty(LedPwm_t* led, uint8_t duty) {
+    if (duty > LED_PWM_MAX_DUTY) duty = LED_PWM_MAX_DUTY;
+    led->duty_percent = duty;
 
-    uint32_t period = led->htim->Init.Period;
-    uint32_t pulse = (period * duty_percent) / 100;
-
+    uint32_t pulse = ((uint32_t)LED_PWM_TIMER_TOP * duty) / LED_PWM_MAX_DUTY;
     __HAL_TIM_SET_COMPARE(led->htim, led->channel, pulse);
 
-    Log(LOG_LEVEL_DEBUG, "LED PWM duty cycle set to %d%% (pulse: %lu)\n", 
+    Log(LOG_LEVEL_DEBUG, "LED PWM duty cycle set to %u (pulse: %lu)\n",
         led->duty_percent, pulse);
 }

--- a/02-proportional-control-v01/Core/Inc/photocell.h
+++ b/02-proportional-control-v01/Core/Inc/photocell.h
@@ -9,6 +9,11 @@
 #define DEFAULT_MIN_READ    0
 #define DEFAULT_MAX_READ   4095
 
+// Maximum value passed to the PWM callback to request full brightness.
+#ifndef PHOTOCELL_PWM_TOP
+#define PHOTOCELL_PWM_TOP 100U
+#endif
+
 #define PHOTOCELL_DEFAULTS { \
     .scaled = DEFAULT_SCALING, \
     .min_value = DEFAULT_MIN_READ, \

--- a/02-proportional-control-v01/Core/Inc/pwm.h
+++ b/02-proportional-control-v01/Core/Inc/pwm.h
@@ -5,6 +5,14 @@
 #include <stdint.h>
 #include "logging.h"
 
+#ifndef PWM_MAX_DUTY
+#define PWM_MAX_DUTY 100U
+#endif
+
+#ifndef PWM_TIMER_TOP
+#define PWM_TIMER_TOP 100U
+#endif
+
 /* Module version definitions. These are maintained alongside the
  * implementation so applications do not need to include a separate
  * version header. Bump the numbers whenever the API or behavior
@@ -25,7 +33,7 @@ typedef struct {
     TIM_HandleTypeDef* htim;  /**< Initialized timer handle controlling the PWM */
     uint32_t channel;         /**< Timer channel (e.g. @ref TIM_CHANNEL_1) */
     uint32_t period;          /**< Timer period (ARR value) used for duty calc */
-    uint8_t duty_percent;     /**< Last duty cycle that was programmed */
+    uint8_t duty_percent;     /**< Last duty cycle value programmed */
 } PwmChannel_t;
 
 /** Initialize a PWM channel instance.

--- a/02-proportional-control-v01/Core/Src/photocell.c
+++ b/02-proportional-control-v01/Core/Src/photocell.c
@@ -43,7 +43,7 @@ void photoCell_autoCalibrate(photoCell_t* sensor, ADC_HandleTypeDef* hadc, void 
     uint32_t sum_high = 0;
 
     // Set LED fully ON
-    set_pwm(100);
+    set_pwm(PHOTOCELL_PWM_TOP);
     HAL_Delay(10000);  // allow sensor to settle
     for (int i = 0; i < samples; i++) {
         HAL_ADC_Start(hadc);

--- a/02-proportional-control-v01/Core/Src/pwm.c
+++ b/02-proportional-control-v01/Core/Src/pwm.c
@@ -15,7 +15,7 @@
 void Pwm_init(PwmChannel_t* pwm, TIM_HandleTypeDef* htim, uint32_t channel) {
     pwm->htim = htim;
     pwm->channel = channel;
-    pwm->period = htim->Init.Period;
+    pwm->period = PWM_TIMER_TOP;
     pwm->duty_percent = 0;
 
     HAL_TIM_PWM_Start(pwm->htim, pwm->channel);
@@ -36,10 +36,10 @@ void Pwm_stop(PwmChannel_t* pwm) {
  * value is clipped to the range 0–100%.
  */
 void Pwm_setDuty(PwmChannel_t* pwm, uint8_t duty_percent) {
-    if (duty_percent > 100) duty_percent = 100;
+    if (duty_percent > PWM_MAX_DUTY) duty_percent = PWM_MAX_DUTY;
     pwm->duty_percent = duty_percent;
 
-    uint32_t pulse = (pwm->period * duty_percent) / 100;
+    uint32_t pulse = (pwm->period * duty_percent) / PWM_MAX_DUTY;
     __HAL_TIM_SET_COMPARE(pwm->htim, pwm->channel, pulse);
 }
 

--- a/02-proportional-control/Core/Inc/led_pwm.h
+++ b/02-proportional-control/Core/Inc/led_pwm.h
@@ -5,13 +5,21 @@
 #include <stdint.h>
 #include "logger.h"
 
+#ifndef LED_PWM_MAX_DUTY
+#define LED_PWM_MAX_DUTY 100U
+#endif
+
+#ifndef LED_PWM_TIMER_TOP
+#define LED_PWM_TIMER_TOP 100U
+#endif
+
 /**
  * @brief PWM-controlled LED interface.
  */
 typedef struct {
     TIM_HandleTypeDef* htim;  /**< Pointer to the timer handle */
     uint32_t channel;         /**< Timer channel used for PWM (e.g., TIM_CHANNEL_1) */
-    uint8_t duty_percent;     /**< Current duty cycle percentage (0–100) */
+    uint8_t duty_percent;     /**< Current duty cycle value (0–LED_PWM_MAX_DUTY) */
 } LedPwm_t;
 
 /**

--- a/02-proportional-control/Core/Src/led_pwm.c
+++ b/02-proportional-control/Core/Src/led_pwm.c
@@ -25,15 +25,13 @@ void LedPwm_stop(LedPwm_t* led) {
         led->channel, (void*)led->htim);
 }
 
-void LedPwm_setDuty(LedPwm_t* led, uint8_t duty_percent) {
-    if (duty_percent > 100) duty_percent = 100;
-    led->duty_percent = duty_percent;
+void LedPwm_setDuty(LedPwm_t* led, uint8_t duty) {
+    if (duty > LED_PWM_MAX_DUTY) duty = LED_PWM_MAX_DUTY;
+    led->duty_percent = duty;
 
-    uint32_t period = led->htim->Init.Period;
-    uint32_t pulse = (period * duty_percent) / 100;
-
+    uint32_t pulse = ((uint32_t)LED_PWM_TIMER_TOP * duty) / LED_PWM_MAX_DUTY;
     __HAL_TIM_SET_COMPARE(led->htim, led->channel, pulse);
 
-    Log(LOG_LEVEL_DEBUG, "LED PWM duty cycle set to %d%% (pulse: %lu)\n", 
+    Log(LOG_LEVEL_DEBUG, "LED PWM duty cycle set to %u (pulse: %lu)\n",
         led->duty_percent, pulse);
 }

--- a/03-pi-control-v01/Core/Inc/photocell.h
+++ b/03-pi-control-v01/Core/Inc/photocell.h
@@ -9,6 +9,11 @@
 #define DEFAULT_MIN_READ    0
 #define DEFAULT_MAX_READ   4095
 
+// Maximum value passed to the PWM callback to request full brightness.
+#ifndef PHOTOCELL_PWM_TOP
+#define PHOTOCELL_PWM_TOP 100U
+#endif
+
 #define PHOTOCELL_DEFAULTS { \
     .scaled = DEFAULT_SCALING, \
     .min_value = DEFAULT_MIN_READ, \

--- a/03-pi-control-v01/Core/Inc/pwm.h
+++ b/03-pi-control-v01/Core/Inc/pwm.h
@@ -5,6 +5,14 @@
 #include <stdint.h>
 #include "logging.h"
 
+#ifndef PWM_MAX_DUTY
+#define PWM_MAX_DUTY 100U
+#endif
+
+#ifndef PWM_TIMER_TOP
+#define PWM_TIMER_TOP 100U
+#endif
+
 /* Module version definitions. These are maintained alongside the
  * implementation so applications do not need to include a separate
  * version header. Bump the numbers whenever the API or behavior
@@ -25,7 +33,7 @@ typedef struct {
     TIM_HandleTypeDef* htim;  /**< Initialized timer handle controlling the PWM */
     uint32_t channel;         /**< Timer channel (e.g. @ref TIM_CHANNEL_1) */
     uint32_t period;          /**< Timer period (ARR value) used for duty calc */
-    uint8_t duty_percent;     /**< Last duty cycle that was programmed */
+    uint8_t duty_percent;     /**< Last duty cycle value programmed */
 } PwmChannel_t;
 
 /** Initialize a PWM channel instance.

--- a/03-pi-control-v01/Core/Src/photocell.c
+++ b/03-pi-control-v01/Core/Src/photocell.c
@@ -43,7 +43,7 @@ void photoCell_autoCalibrate(photoCell_t* sensor, ADC_HandleTypeDef* hadc, void 
     uint32_t sum_high = 0;
 
     // Set LED fully ON
-    set_pwm(100);
+    set_pwm(PHOTOCELL_PWM_TOP);
     HAL_Delay(10000);  // allow sensor to settle
     for (int i = 0; i < samples; i++) {
         HAL_ADC_Start(hadc);

--- a/03-pi-control-v01/Core/Src/pwm.c
+++ b/03-pi-control-v01/Core/Src/pwm.c
@@ -15,7 +15,7 @@
 void Pwm_init(PwmChannel_t* pwm, TIM_HandleTypeDef* htim, uint32_t channel) {
     pwm->htim = htim;
     pwm->channel = channel;
-    pwm->period = htim->Init.Period;
+    pwm->period = PWM_TIMER_TOP;
     pwm->duty_percent = 0;
 
     HAL_TIM_PWM_Start(pwm->htim, pwm->channel);
@@ -36,10 +36,10 @@ void Pwm_stop(PwmChannel_t* pwm) {
  * value is clipped to the range 0–100%.
  */
 void Pwm_setDuty(PwmChannel_t* pwm, uint8_t duty_percent) {
-    if (duty_percent > 100) duty_percent = 100;
+    if (duty_percent > PWM_MAX_DUTY) duty_percent = PWM_MAX_DUTY;
     pwm->duty_percent = duty_percent;
 
-    uint32_t pulse = (pwm->period * duty_percent) / 100;
+    uint32_t pulse = (pwm->period * duty_percent) / PWM_MAX_DUTY;
     __HAL_TIM_SET_COMPARE(pwm->htim, pwm->channel, pulse);
 }
 

--- a/03-pi-control-v02/Core/Inc/photocell.h
+++ b/03-pi-control-v02/Core/Inc/photocell.h
@@ -9,6 +9,11 @@
 #define DEFAULT_MIN_READ    0
 #define DEFAULT_MAX_READ   4095
 
+// Maximum value passed to the PWM callback to request full brightness.
+#ifndef PHOTOCELL_PWM_TOP
+#define PHOTOCELL_PWM_TOP 100U
+#endif
+
 #define PHOTOCELL_DEFAULTS { \
     .scaled = DEFAULT_SCALING, \
     .min_value = DEFAULT_MIN_READ, \

--- a/03-pi-control-v02/Core/Inc/pwm.h
+++ b/03-pi-control-v02/Core/Inc/pwm.h
@@ -5,6 +5,20 @@
 #include <stdint.h>
 #include "logging.h"
 
+/*
+ * These macros allow the application to define the range used for the PWM
+ * duty cycle and the corresponding timer top value.  By default the driver
+ * expects a percentage input (0-100) and a timer period of 100 ticks.  Define
+ * PWM_MAX_DUTY and PWM_TIMER_TOP before including this header to override.
+ */
+#ifndef PWM_MAX_DUTY
+#define PWM_MAX_DUTY 100U
+#endif
+
+#ifndef PWM_TIMER_TOP
+#define PWM_TIMER_TOP 100U
+#endif
+
 /* Module version definitions. These are maintained alongside the
  * implementation so applications do not need to include a separate
  * version header. Bump the numbers whenever the API or behavior
@@ -25,7 +39,7 @@ typedef struct {
     TIM_HandleTypeDef* htim;  /**< Initialized timer handle controlling the PWM */
     uint32_t channel;         /**< Timer channel (e.g. @ref TIM_CHANNEL_1) */
     uint32_t period;          /**< Timer period (ARR value) used for duty calc */
-    uint8_t duty_percent;     /**< Last duty cycle that was programmed */
+    uint8_t duty_percent;     /**< Last duty cycle value programmed */
 } PwmChannel_t;
 
 /** Initialize a PWM channel instance.

--- a/03-pi-control-v02/Core/Src/photocell.c
+++ b/03-pi-control-v02/Core/Src/photocell.c
@@ -43,7 +43,7 @@ void photoCell_autoCalibrate(photoCell_t* sensor, ADC_HandleTypeDef* hadc, void 
     uint32_t sum_high = 0;
 
     // Set LED fully ON
-    set_pwm(255);
+    set_pwm(PHOTOCELL_PWM_TOP);
     HAL_Delay(100);  // allow sensor to settle
     for (int i = 0; i < samples; i++) {
         HAL_ADC_Start(hadc);

--- a/03-pi-control-v02/Core/Src/pwm.c
+++ b/03-pi-control-v02/Core/Src/pwm.c
@@ -15,7 +15,7 @@
 void Pwm_init(PwmChannel_t* pwm, TIM_HandleTypeDef* htim, uint32_t channel) {
     pwm->htim = htim;
     pwm->channel = channel;
-    pwm->period = htim->Init.Period;
+    pwm->period = PWM_TIMER_TOP;
     pwm->duty_percent = 0;
 
     HAL_TIM_PWM_Start(pwm->htim, pwm->channel);
@@ -36,10 +36,10 @@ void Pwm_stop(PwmChannel_t* pwm) {
  * value is clipped to the range 0–100%.
  */
 void Pwm_setDuty(PwmChannel_t* pwm, uint8_t duty_percent) {
-    if (duty_percent > 100) duty_percent = 100;
+    if (duty_percent > PWM_MAX_DUTY) duty_percent = PWM_MAX_DUTY;
     pwm->duty_percent = duty_percent;
 
-    uint32_t pulse = (pwm->period * duty_percent) / 100;
+    uint32_t pulse = (pwm->period * duty_percent) / PWM_MAX_DUTY;
     __HAL_TIM_SET_COMPARE(pwm->htim, pwm->channel, pulse);
 }
 

--- a/03-pi_control/Core/Inc/led_pwm.h
+++ b/03-pi_control/Core/Inc/led_pwm.h
@@ -6,12 +6,33 @@
 #include "logger.h"
 
 /**
+ * @brief Maximum value accepted by ::LedPwm_setDuty.
+ *
+ * The default assumes a percentage based API (0-100).  Define this macro
+ * prior to including this header if your application uses a different range.
+ */
+#ifndef LED_PWM_MAX_DUTY
+#define LED_PWM_MAX_DUTY 100U
+#endif
+
+/**
+ * @brief Timer top value used to generate 100% duty cycle.
+ *
+ * Set this to match the timer's auto-reload register (ARR) value.  The driver
+ * no longer reads the value from the HAL timer structure so the user must
+ * provide it explicitly.
+ */
+#ifndef LED_PWM_TIMER_TOP
+#define LED_PWM_TIMER_TOP 100U
+#endif
+
+/**
  * @brief PWM-controlled LED interface.
  */
 typedef struct {
     TIM_HandleTypeDef* htim;  /**< Pointer to the timer handle */
     uint32_t channel;         /**< Timer channel used for PWM (e.g., TIM_CHANNEL_1) */
-    uint8_t duty_percent;     /**< Current duty cycle percentage (0–100) */
+    uint8_t duty_percent;     /**< Current duty cycle value (0–LED_PWM_MAX_DUTY) */
 } LedPwm_t;
 
 /**

--- a/03-pi_control/Core/Inc/photocell.h
+++ b/03-pi_control/Core/Inc/photocell.h
@@ -9,6 +9,12 @@
 #define DEFAULT_MIN_READ    0
 #define DEFAULT_MAX_READ   4095
 
+// Maximum value passed to the PWM callback to request full brightness.
+// Set this to match the range expected by your PWM driver.
+#ifndef PHOTOCELL_PWM_TOP
+#define PHOTOCELL_PWM_TOP 100U
+#endif
+
 typedef struct {
     bool scaled;              // Whether to scale result to 0–100
     uint16_t min_value;       // Raw ADC value mapped to "0%"

--- a/03-pi_control/Core/Src/led_pwm.c
+++ b/03-pi_control/Core/Src/led_pwm.c
@@ -25,15 +25,13 @@ void LedPwm_stop(LedPwm_t* led) {
         led->channel, (void*)led->htim);
 }
 
-void LedPwm_setDuty(LedPwm_t* led, uint8_t duty_percent) {
-    if (duty_percent > 100) duty_percent = 100;
-    led->duty_percent = duty_percent;
+void LedPwm_setDuty(LedPwm_t* led, uint8_t duty) {
+    if (duty > LED_PWM_MAX_DUTY) duty = LED_PWM_MAX_DUTY;
+    led->duty_percent = duty;
 
-    uint32_t period = led->htim->Init.Period;
-    uint32_t pulse = (period * duty_percent) / 100;
-
+    uint32_t pulse = ((uint32_t)LED_PWM_TIMER_TOP * duty) / LED_PWM_MAX_DUTY;
     __HAL_TIM_SET_COMPARE(led->htim, led->channel, pulse);
 
-    Log(LOG_LEVEL_DEBUG, "LED PWM duty cycle set to %d%% (pulse: %lu)\n", 
+    Log(LOG_LEVEL_DEBUG, "LED PWM duty cycle set to %u (pulse: %lu)\n",
         led->duty_percent, pulse);
 }

--- a/03-pi_control/Core/Src/photocell.c
+++ b/03-pi_control/Core/Src/photocell.c
@@ -46,7 +46,7 @@ void photoCell_autoCalibrate(photoCell_t* sensor, ADC_HandleTypeDef* hadc, void 
     uint32_t sum_high = 0;
 
     // Set LED fully ON
-    set_pwm(255);
+    set_pwm(PHOTOCELL_PWM_TOP);
     HAL_Delay(100);  // allow sensor to settle
     for (int i = 0; i < samples; i++) {
         if (HAL_ADC_Start(hadc) != HAL_OK ||


### PR DESCRIPTION
## Summary
- allow LED PWM and generic PWM modules to use user-defined max duty and timer top values
- add `PHOTOCELL_PWM_TOP` macro and use it during auto calibration
- drop automatic timer period detection in PWM helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688ff13945d0832391a0e50fa7bf783b