### PR TITLE
Add FreeRTOS-aware delay macro

### DIFF
--- a/03-pi-control-v02/Core/Inc/delay.h
+++ b/03-pi-control-v02/Core/Inc/delay.h
@@ -10,7 +10,7 @@
  * CMSIS-RTOS v1, providing a non-blocking delay that allows other
  * tasks to run. Otherwise it falls back to the standard HAL_Delay.
  */
-#define PID_DELAY(ms) osDelay(ms)
+#define PID_DELAY(ms) osDelay(pdMS_TO_TICKS(ms))
 #else
 #define PID_DELAY(ms) HAL_Delay(ms)
 #endif

--- a/03-pi-control-v02/Core/Inc/delay.h
+++ b/03-pi-control-v02/Core/Inc/delay.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "stm32f4xx_hal.h"
+
+#ifdef USE_FREERTOS
+#include "cmsis_os.h"
+/**
+ * @brief Delay macro that cooperates with FreeRTOS scheduler.
+ *
+ * When USE_FREERTOS is defined, this macro maps to osDelay from
+ * CMSIS-RTOS v1, providing a non-blocking delay that allows other
+ * tasks to run. Otherwise it falls back to the standard HAL_Delay.
+ */
+#define PID_DELAY(ms) osDelay(ms)
+#else
+#define PID_DELAY(ms) HAL_Delay(ms)
+#endif

--- a/03-pi-control-v02/Core/Src/photocell.c
+++ b/03-pi-control-v02/Core/Src/photocell.c
@@ -1,5 +1,5 @@
 #include "photocell.h"
-#include "stm32f4xx_hal.h"  // HAL definitions for STM32F4
+#include "delay.h"  // HAL or FreeRTOS delay abstraction
 
 /**
  * @brief Maps a value from one range to another.
@@ -44,7 +44,7 @@ void photoCell_autoCalibrate(photoCell_t* sensor, ADC_HandleTypeDef* hadc, void 
 
     // Set LED fully ON
     set_pwm(255);
-    HAL_Delay(100);  // allow sensor to settle
+    PID_DELAY(100);  // allow sensor to settle
     for (int i = 0; i < samples; i++) {
         HAL_ADC_Start(hadc);
         HAL_ADC_PollForConversion(hadc, HAL_MAX_DELAY);
@@ -53,7 +53,7 @@ void photoCell_autoCalibrate(photoCell_t* sensor, ADC_HandleTypeDef* hadc, void 
 
     // Set LED fully OFF
     set_pwm(0);
-    HAL_Delay(100);  // allow sensor to settle
+    PID_DELAY(100);  // allow sensor to settle
     for (int i = 0; i < samples; i++) {
         HAL_ADC_Start(hadc);
         HAL_ADC_PollForConversion(hadc, HAL_MAX_DELAY);


### PR DESCRIPTION
## Summary
- add `PID_DELAY` macro that uses HAL_Delay or osDelay depending on USE_FREERTOS
- use the new delay macro in the photocell driver to avoid blocking the scheduler

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_688ff43ccfb88323955a666ddc3e30de