### PR TITLE
Fix autocalibration PWM so LED reaches full brightness

### DIFF
--- a/PI-Control/Core/Inc/photocell.h
+++ b/PI-Control/Core/Inc/photocell.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "stm32f4xx_hal.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#define PHOTOCELL_ADC_TIMEOUT_MS 10U
+
+typedef struct {
+    bool scaled;              // output scaled to 0-100%
+    float current_level;      // last scaled level
+    uint16_t last_raw_value;  // last raw ADC reading
+    uint16_t min_value;       // calibrated minimum raw value
+    uint16_t max_value;       // calibrated maximum raw value
+    ADC_HandleTypeDef *hadc;  // ADC handle used for measurements
+    TIM_HandleTypeDef *htim;  // PWM timer handle for LED control
+    uint32_t pwm_channel;     // PWM channel for LED control
+} photoCell_t;
+
+void photoCell_init(photoCell_t *sensor, ADC_HandleTypeDef *hadc);
+void photoCell_autoCalibrate(photoCell_t *sensor, TIM_HandleTypeDef *htim, uint32_t channel);
+float readSensor(photoCell_t *sensor);
+
+// simple helper to set a PWM compare value
+void set_pwm(TIM_HandleTypeDef *htim, uint32_t channel, uint32_t value);
+

--- a/PI-Control/Core/Src/photocell.c
+++ b/PI-Control/Core/Src/photocell.c
@@ -1,0 +1,81 @@
+#include "photocell.h"
+
+static inline uint32_t map_range(uint32_t x, uint32_t in_min, uint32_t in_max,
+                                 uint32_t out_min, uint32_t out_max) {
+    return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
+
+void set_pwm(TIM_HandleTypeDef *htim, uint32_t channel, uint32_t value) {
+    if (htim == NULL)
+        return;
+    __HAL_TIM_SET_COMPARE(htim, channel, value);
+}
+
+void photoCell_init(photoCell_t *sensor, ADC_HandleTypeDef *hadc) {
+    sensor->scaled = true;
+    sensor->current_level = 0.0f;
+    sensor->last_raw_value = 0;
+    sensor->min_value = 0;
+    sensor->max_value = 4095;
+    sensor->hadc = hadc;
+    sensor->htim = NULL;
+    sensor->pwm_channel = UINT32_MAX;
+}
+
+void photoCell_autoCalibrate(photoCell_t *sensor, TIM_HandleTypeDef *htim, uint32_t channel) {
+    sensor->htim = htim;
+    sensor->pwm_channel = channel;
+
+    const int samples = 16;
+    uint32_t sum_low = 0;
+    uint32_t sum_high = 0;
+
+    // Start PWM and drive LED fully on
+    HAL_TIM_PWM_Start(htim, channel);
+    set_pwm(htim, channel, htim->Init.Period); // full duty cycle
+    HAL_Delay(100);
+    for (int i = 0; i < samples; ++i) {
+        if (HAL_ADC_Start(sensor->hadc) != HAL_OK ||
+            HAL_ADC_PollForConversion(sensor->hadc, PHOTOCELL_ADC_TIMEOUT_MS) != HAL_OK)
+            return;
+        sum_high += HAL_ADC_GetValue(sensor->hadc);
+    }
+
+    // Turn LED fully off
+    set_pwm(htim, channel, 0);
+    HAL_Delay(100);
+    for (int i = 0; i < samples; ++i) {
+        if (HAL_ADC_Start(sensor->hadc) != HAL_OK ||
+            HAL_ADC_PollForConversion(sensor->hadc, PHOTOCELL_ADC_TIMEOUT_MS) != HAL_OK)
+            return;
+        sum_low += HAL_ADC_GetValue(sensor->hadc);
+    }
+
+    sensor->max_value = sum_high / samples;
+    sensor->min_value = sum_low / samples;
+}
+
+float readSensor(photoCell_t *sensor) {
+    if (HAL_ADC_Start(sensor->hadc) != HAL_OK ||
+        HAL_ADC_PollForConversion(sensor->hadc, PHOTOCELL_ADC_TIMEOUT_MS) != HAL_OK)
+        return sensor->current_level;
+
+    uint16_t raw = HAL_ADC_GetValue(sensor->hadc);
+    sensor->last_raw_value = raw;
+
+    if (sensor->scaled) {
+        if (raw <= sensor->min_value) {
+            sensor->current_level = 0.0f;
+        } else if (raw >= sensor->max_value) {
+            sensor->current_level = 100.0f;
+        } else {
+            sensor->current_level = (float)map_range(raw, sensor->min_value,
+                                                     sensor->max_value, 0, 100);
+        }
+    } else {
+        sensor->current_level = (float)raw;
+    }
+
+    return sensor->current_level;
+}
+


### PR DESCRIPTION
## Summary
- add a standalone photocell module for PI-Control
- drive PWM at timer period during autocalibration to fully power the LED
- expose helper to update PWM compare value

## Testing
- `cd tests && rm -rf build && cmake -S . -B build`
- `cd tests && cmake --build build`
- `cd tests && ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68900eaa86ac832380944aed7c247e18