### PR TITLE
Add PI controller

### DIFF
--- a/03-pi-control/Core/Inc/pid.h
+++ b/03-pi-control/Core/Inc/pid.h
@@ -1,0 +1,114 @@
+/**
+ * @file    pid.h
+ * @brief   Tiny PI controller suitable for embedded targets.
+ *
+ * Copyright (c) 2025 Kevin Fox
+ * SPDX-License-Identifier: MIT
+ *
+ * Usage:
+ *     #include "pid.h"
+ *     pid_t ctrl = PID_DEFAULTS;
+ *     PID_INIT(&ctrl);                 // or pid_init(&ctrl, …) for run-time tweaking
+ *     …
+ *     float u = PID_COMPUTE(&ctrl, measured_value);
+ *     set_pwm_duty(u);                 // clamp already handled inside PID_COMPUTE
+ */
+
+#ifndef PID_H
+#define PID_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* --------------------------------------------------------------------
+ * Compile-time configuration
+ * Override these with -D<NAME>=<value> on the compiler command line
+ * or just edit them here.
+ * ------------------------------------------------------------------*/
+#ifndef PID_KP
+#define PID_KP            1.0f      /**< Proportional gain */
+#endif
+
+#ifndef PID_KI
+#define PID_KI            0.0f      /**< Integral gain */
+#endif
+
+#ifndef PID_SETPOINT
+#define PID_SETPOINT      100.0f    /**< Desired process value */
+#endif
+
+#ifndef PID_OUT_MIN
+#define PID_OUT_MIN       0.0f      /**< Lower clamp for controller output */
+#endif
+
+#ifndef PID_OUT_MAX
+#define PID_OUT_MAX       100.0f    /**< Upper clamp for controller output */
+#endif
+
+/* --------------------------------------------------------------------
+ * Data structure
+ * ------------------------------------------------------------------*/
+typedef struct
+{
+    float Kp;          /**< Proportional gain                  */
+    float Ki;          /**< Integral gain                      */
+    float setpoint;    /**< Target value                       */
+    float integral;    /**< Accumulated integral term          */
+    float out_min;     /**< Minimum allowed controller output  */
+    float out_max;     /**< Maximum allowed controller output  */
+} pid_t;
+
+/* Macro that yields a fully-initialised instance using the
+ * default #defines above.  Example:
+ *     pid_t led_ctrl = PID_DEFAULTS;
+ */
+#define PID_DEFAULTS \
+{                     \
+    .Kp        = PID_KP,       \
+    .Ki        = PID_KI,       \
+    .setpoint  = PID_SETPOINT, \
+    .integral  = 0.0f,         \
+    .out_min   = PID_OUT_MIN,  \
+    .out_max   = PID_OUT_MAX   \
+}
+
+/* --------------------------------------------------------------------
+ * API
+ * ------------------------------------------------------------------*/
+
+/**
+ * @brief  Initialise (or re-initialise) a controller at run time.
+ * @param  pid       Pointer to controller instance
+ * @param  kp        Proportional gain
+ * @param  ki        Integral gain
+ * @param  setpoint  Desired process value
+ * @param  out_min   Lower saturation limit
+ * @param  out_max   Upper saturation limit
+ */
+void pid_init(pid_t *pid,
+              float  kp,
+              float  ki,
+              float  setpoint,
+              float  out_min,
+              float  out_max);
+
+/**
+ * @brief  Return the control effort for the current measurement.
+ *         Output is clamped to [out_min, out_max].
+ * @param  pid       Pointer to controller instance
+ * @param  measured  Current process value
+ * @return float     Controller output
+ */
+float pid_compute(pid_t *pid, float measured);
+
+/* -------------- Convenience macro (computes in-place) -------------- */
+#define PID_COMPUTE(pid_ptr, meas)  pid_compute((pid_ptr), (meas))
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PID_H */

--- a/03-pi-control/Core/Src/pid.c
+++ b/03-pi-control/Core/Src/pid.c
@@ -1,0 +1,38 @@
+/**
+ * @file    pid.c
+ * @brief   Implementation of proportional-integral controller.
+ */
+
+#include "pid.h"
+
+/* ----------------------------- Helpers ----------------------------- */
+static inline float pid_clamp(float v, float lo, float hi)
+{
+    if (v > hi) return hi;
+    if (v < lo) return lo;
+    return v;
+}
+
+/* --------------------------- Public API ---------------------------- */
+void pid_init(pid_t *pid,
+              float  kp,
+              float  ki,
+              float  setpoint,
+              float  out_min,
+              float  out_max)
+{
+    pid->Kp        = kp;
+    pid->Ki        = ki;
+    pid->setpoint  = setpoint;
+    pid->integral  = 0.0f;
+    pid->out_min   = out_min;
+    pid->out_max   = out_max;
+}
+
+float pid_compute(pid_t *pid, float measured)
+{
+    float error = pid->setpoint - measured;
+    pid->integral += error;
+    float output = pid->Kp * error + pid->Ki * pid->integral;
+    return pid_clamp(output, pid->out_min, pid->out_max);
+}

--- a/03-pi-control/cmake/stm32cubemx/CMakeLists.txt
+++ b/03-pi-control/cmake/stm32cubemx/CMakeLists.txt
@@ -29,6 +29,7 @@ set(MX_Application_Src
     ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/Src/stm32f4xx_hal_timebase_tim.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/Src/sysmem.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/Src/syscalls.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/Src/pid.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../startup_stm32f446xx.s
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,8 +3,8 @@ project(pid_tests C)
 
 set(CMAKE_C_STANDARD 11)
 
-add_executable(pid_test pid_test.c ../02-proportional-control/Core/Src/pid.c)
-target_include_directories(pid_test PRIVATE ../02-proportional-control/Core/Inc)
+add_executable(pid_test pid_test.c ../03-pi-control/Core/Src/pid.c)
+target_include_directories(pid_test PRIVATE ../03-pi-control/Core/Inc)
 target_link_libraries(pid_test m)
 
 enable_testing()

--- a/tests/pid_test.c
+++ b/tests/pid_test.c
@@ -1,11 +1,12 @@
 #include <assert.h>
 #include <math.h>
-#include "../02-proportional-control/Core/Inc/pid.h"
+#include "../03-pi-control/Core/Inc/pid.h"
 
 int main(void) {
     pid_t pid;
-    pid_init(&pid, 1.0f, 100.0f, 0.0f, 100.0f);
 
+    // Proportional-only behaviour
+    pid_init(&pid, 1.0f, 0.0f, 100.0f, 0.0f, 100.0f);
     float out = pid_compute(&pid, 100.0f);
     assert(fabsf(out - 0.0f) < 1e-6);
 
@@ -14,6 +15,14 @@ int main(void) {
 
     out = pid_compute(&pid, 200.0f);
     assert(fabsf(out - 0.0f) < 1e-6);
+
+    // Integral accumulation behaviour
+    pid_init(&pid, 0.0f, 0.5f, 10.0f, 0.0f, 100.0f);
+    out = pid_compute(&pid, 0.0f);   // error=10 -> integral=10 -> output=5
+    assert(fabsf(out - 5.0f) < 1e-6);
+
+    out = pid_compute(&pid, 0.0f);   // integral=20 -> output=10
+    assert(fabsf(out - 10.0f) < 1e-6);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- copy PID code into 03-pi-control and expand for proportional-integral operation
- exercise PI controller through updated unit tests
- include pid.c in 03-pi-control build configuration

## Testing
- `cmake -S tests -B tests/build`
- `cmake --build tests/build`
- `ctest --test-dir tests/build`

------
https://chatgpt.com/codex/tasks/task_e_6897a409ddf08323842376d6130ad8da